### PR TITLE
Fix compiler warnings

### DIFF
--- a/pyorient_native/listener.cpp
+++ b/pyorient_native/listener.cpp
@@ -8,34 +8,7 @@
 #include "math.h"
 #include "datetime.h"
 #include "string.h"
-
-/* From https://stackoverflow.com/questions/43088062/version-comparison-in-c-using-strtok */
-int ver_comp(char *v1, char *v2)
-{
-  int res = 0;
-  char *next_1 = v1;
-  char *next_2 = v2;
-
-  while (*next_1 != '\0' && *next_2 != '\0') {
-    long x1 = strtol(v1, &next_1, 10);
-    long x2 = strtol(v2, &next_2, 10);
-
-    res = x1 - x2;
-    if (res) {
-      break;
-    }
-
-    if (*next_1 == '\0' || *next_2 == '\0') {
-      res = *next_1 - *next_2;
-      break;
-    }
-
-    v1 = next_1 + 1;
-    v2 = next_2 + 1;
-  }
-
-  return res;
-}
+#include "version_compare.h"
 
 using namespace Orient;
 using namespace std;
@@ -385,7 +358,7 @@ TrackerListener::TrackerListener(PyObject* props) {
   PyObject *version_pystring = PyObject_GetAttrString(pyorient_constants, "VERSION");
   char *version = PyString_AsString(version_pystring);
   Py_XDECREF(version_pystring);
-  if(ver_comp(version, "1.5.5") > 0)
+  if((Version)(version) > (Version)("1.5.5"))
     this->legacy_link = false;
   else
     this->legacy_link = true;

--- a/pyorient_native/orientc_reader.cpp
+++ b/pyorient_native/orientc_reader.cpp
@@ -9,7 +9,7 @@
 #if PY_MAJOR_VERSION >= 3
 char* PyString_AsString(PyObject* obj){
   if(obj==NULL)
-    return "";
+    return (char *)("");
   if (PyUnicode_Check(obj)) {
     char* rv;
     PyObject * byte_obj = PyUnicode_AsEncodedString(obj, "ASCII", "strict");

--- a/pyorient_native/version_compare.h
+++ b/pyorient_native/version_compare.h
@@ -1,0 +1,71 @@
+/* Sam Caldwell <mail@samcaldwell.net> (released public domain to the project where this code resides).
+ * Version Comparison Class.
+ *
+ * Given a version string in the form xxx.yyy.zzz.aaa, this class will parse the string
+ * and allow version comparison operators to test equivalence, etc. Expected behavior is
+ * defined in test_version_compare.cpp (in tests/ directory).
+ *
+ */
+#ifndef VERSION_COMPARE_H
+#define VERSION_COMPARE_H
+#endif
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+class Version {
+public:
+	Version(const char *c){
+		string version(c);
+		this->major = 0;
+		this->minor = 0;
+		this->revision = 0;
+		this->build = 0;
+		std::sscanf(version.c_str(), "%d.%d.%d.%d", &this->major, &this->minor, &this->revision, &this->build);
+	}
+
+	bool operator<(const Version rhs){
+		if (this->major < rhs.major)
+			return true;
+		if (this->minor < rhs.minor)
+			return true;
+		if (this->revision < rhs.revision)
+			return true;
+		if (this->build < rhs.build)
+			return true;
+		return false;
+	}
+
+	bool operator>(const Version rhs){
+		if (this->major > rhs.major)
+			return true;
+		if (this->minor > rhs.minor)
+			return true;
+		if (this->revision > rhs.revision)
+			return true;
+		if (this->build > rhs.build)
+			return true;
+		return false;
+	}
+
+	bool operator==(const Version rhs){
+		return this->major == rhs.major
+			   && this->minor == rhs.minor
+			   && this->revision == rhs.revision
+			   && this->build == rhs.build;
+	}
+
+	bool operator!=(const Version rhs){
+		return this->major != rhs.major
+			   && this->minor != rhs.minor
+			   && this->revision != rhs.revision
+			   && this->build != rhs.build;
+	}
+
+public:
+	int major = 0;
+	int minor = 0;
+	int revision = 0;
+	int build = 0;
+};

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,40 @@
 from setuptools import find_packages, setup, Extension
 
-h_files = ["pyorient_native/orientc_reader.h", "pyorient_native/orientc_writer.h",
-           "pyorient_native/orientc.h","pyorient_native/helpers.h","pyorient_native/parse_exception.h",
-                                            "pyorient_native/listener.h", "pyorient_native/encoder.h","pyorient_native/pendian.h"]
-pyorient_native = Extension("pyorient_native", sources=["pyorient_native/orientc_reader.cpp", "pyorient_native/orientc_writer.cpp",
-                                     "pyorient_native/helpers.cpp", "pyorient_native/parse_exception.cpp",
-                                     "pyorient_native/listener.cpp", "pyorient_native/encoder.cpp",
-                                     "pyorient_native/pyorient_native.cpp"],
-                            depends = h_files,
-                            library_dirs = [],
-                            include_dirs = ["./pyorient_native"],
-                    language="c++", libraries=["stdc++"])
+h_files = [
+    "pyorient_native/orientc_reader.h",
+    "pyorient_native/orientc_writer.h",
+    "pyorient_native/orientc.h",
+    "pyorient_native/helpers.h",
+    "pyorient_native/parse_exception.h",
+    "pyorient_native/listener.h",
+    "pyorient_native/encoder.h",
+    "pyorient_native/pendian.h"
+]
+pyorient_native = Extension(
+    "pyorient_native",
+    sources=[
+        "pyorient_native/orientc_reader.cpp",
+        "pyorient_native/orientc_writer.cpp",
+        "pyorient_native/helpers.cpp",
+        "pyorient_native/parse_exception.cpp",
+        "pyorient_native/listener.cpp",
+        "pyorient_native/encoder.cpp",
+        "pyorient_native/pyorient_native.cpp"],
+    depends=h_files,
+    library_dirs=[],
+    include_dirs=["./pyorient_native"],
+    language="c++",
+    libraries=["stdc++"]
+)
 setup(
-    name = "pyorient_native",
+    name="pyorient_native",
     version="1.2.3",
     description="OrientDB Binary Serialization package for python",
     author="Nikul Ukani",
     author_email="nhu2001@columbia.edu",
-    ext_modules = [pyorient_native],
+    ext_modules=[pyorient_native],
     packages=find_packages(),
     url="https://github.com/nikulukani/pyorient_native",
-    download_url="https://github.com/nikulukani/pyorient_native/archive/1.2.3.tar.gz" 
-    )
+    download_url="https://github.com/nikulukani/pyorient_native/"
+                 "archive/1.2.3.tar.gz"
+)

--- a/tests/test_version_compare.cpp
+++ b/tests/test_version_compare.cpp
@@ -1,0 +1,110 @@
+/* Sam Caldwell <mail@samcaldwell.net> (released public domain to the project where this code resides).
+ * This file contains the tests for the version_compare.h source file.
+ */
+#include "../pyorient_native/version_compare.h"
+#include <assert.h>
+#include <iostream>
+
+/*void show_values(Version v1, Version v2){
+	cout << "show_values():\n";
+	cout << "\tv1: " << v1.major << "." << v1.minor << "." << v1.revision << "." << v1.build << "\n";
+	cout << "\tv2: " << v2.major << "." << v2.minor << "." << v2.revision << "." << v2.build << "\n";
+	cout << "\t---\n";
+}*/
+
+bool test_equivalence_operator_happy(){
+	cout << "test: test_equivalence_operator_happy() starting\n";
+	const char *version_string = "1.0.0";
+
+	Version v1(version_string);
+	Version v2(version_string);
+
+	return (v1 == v2);
+}
+
+bool test_equivalence_operator_sad(){
+	cout << "test: test_equivalence_operator_sad(): starting\n";
+	const char *version_string1 = "1.0.0";
+	const char *version_string2 = "2.0.0";
+
+	Version v1(version_string1);
+	Version v2(version_string2);
+
+	return !(v1 == v2);
+}
+
+bool test_less_than_operator_happy(){
+	cout << "test: test_less_than_operator_happy(): starting\n";
+	const char *version_string1 = "1.0.0";
+	const char *version_string2 = "1.0.1";
+
+	Version v1(version_string1);
+	Version v2(version_string2);
+
+	return (v1 < v2);
+}
+
+bool test_less_than_operator_sad_if_equal(){
+	cout << "test: test_less_than_operator_sad_if_equal(): starting\n";
+	const char *version_string1 = "1.0.0";
+	const char *version_string2 = "1.0.0";
+
+	Version v1(version_string1);
+	Version v2(version_string2);
+
+	return !(v1 < v2);
+}
+
+bool test_less_than_operator_sad_if_greater(){
+	cout << "test: test_less_than_operator_sad_if_greater(): starting\n";
+	const char *version_string1 = "2.0.0";
+	const char *version_string2 = "1.0.0";
+
+	Version v1(version_string1);
+	Version v2(version_string2);
+
+	return !(v1 < v2);
+}
+
+bool test_inequal_operator_happy(){
+	cout << "test: test_less_than_operator_sad_if_greater(): starting\n";
+	const char *version_string1 = "2.0.0";
+	const char *version_string2 = "1.0.0";
+
+	Version v1(version_string1);
+	Version v2(version_string2);
+
+	return (v1 != v2);
+}
+
+bool test_inequal_operator_sad(){
+	cout << "test: test_less_than_operator_sad_if_greater(): starting\n";
+	const char *version_string1 = "1.0.0";
+	const char *version_string2 = "1.0.0";
+
+	Version v1(version_string1);
+	Version v2(version_string2);
+
+	return !(v1 != v2);
+}
+
+bool test_casted_comparison_happy(){
+	cout << "test: test_casted_comparison_happy(): starting\n";
+	return (Version)("1.0") == (Version)("1.0");
+}
+bool test_casted_comparison_sad(){
+	cout << "test: test_casted_comparison_sad(): starting\n";
+	return (Version)("1.0") == (Version)("1.0");
+}
+
+int main(){
+	cout << "\n\nStarting tests.\n";
+
+	assert (test_equivalence_operator_happy());
+	assert (test_equivalence_operator_sad());
+	assert (test_less_than_operator_happy());
+	assert (test_less_than_operator_sad_if_equal());
+	assert (test_less_than_operator_sad_if_greater());
+	assert (test_casted_comparison_happy());
+	assert (test_casted_comparison_sad());
+}


### PR DESCRIPTION
A compiler warning exists during compile from source where "ISO C++ forbids converting a string constant to 'char*'"

This warning exists in two places: 
(1) version comparison in listener.cpp
(2) orientc_reader.cpp

This pull request resolves these warnings by--
(1) Implementing a more robust Version class with comparison operators.
(2) Explicitly casting an empty ("") string to char *

A test for the version class has been added with this pull requests in a tests/ directory which can be extended to add unit tests as further code analysis is performed.