### PR TITLE
Fix macos warnings, implement tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@
 #Ignore jetbrains project files
 .idea/
 *.iml
+
+dist/
+pyorient_native.egg-info/
+tests/__pycache__/
+tests/bin/*

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@
 *.exe
 *.out
 *.app
+
+#Ignore jetbrains project files
+.idea/
+*.iml

--- a/pyorient_native/listener.cpp
+++ b/pyorient_native/listener.cpp
@@ -8,34 +8,7 @@
 #include "math.h"
 #include "datetime.h"
 #include "string.h"
-
-/* From https://stackoverflow.com/questions/43088062/version-comparison-in-c-using-strtok */
-int ver_comp(char *v1, char *v2)
-{
-  int res = 0;
-  char *next_1 = v1;
-  char *next_2 = v2;
-
-  while (*next_1 != '\0' && *next_2 != '\0') {
-    long x1 = strtol(v1, &next_1, 10);
-    long x2 = strtol(v2, &next_2, 10);
-
-    res = x1 - x2;
-    if (res) {
-      break;
-    }
-
-    if (*next_1 == '\0' || *next_2 == '\0') {
-      res = *next_1 - *next_2;
-      break;
-    }
-
-    v1 = next_1 + 1;
-    v2 = next_2 + 1;
-  }
-
-  return res;
-}
+#include "version_compare.h"
 
 using namespace Orient;
 using namespace std;
@@ -385,7 +358,7 @@ TrackerListener::TrackerListener(PyObject* props) {
   PyObject *version_pystring = PyObject_GetAttrString(pyorient_constants, "VERSION");
   char *version = PyString_AsString(version_pystring);
   Py_XDECREF(version_pystring);
-  if(ver_comp(version, "1.5.5") > 0)
+  if((Version)(version) > (Version)("1.5.5"))
     this->legacy_link = false;
   else
     this->legacy_link = true;

--- a/pyorient_native/orientc_reader.cpp
+++ b/pyorient_native/orientc_reader.cpp
@@ -9,7 +9,7 @@
 #if PY_MAJOR_VERSION >= 3
 char* PyString_AsString(PyObject* obj){
   if(obj==NULL)
-    return "";
+    return (char *)("");
   if (PyUnicode_Check(obj)) {
     char* rv;
     PyObject * byte_obj = PyUnicode_AsEncodedString(obj, "ASCII", "strict");

--- a/pyorient_native/pendian.h
+++ b/pyorient_native/pendian.h
@@ -1,51 +1,61 @@
 #ifndef PORTABLE_ENDIAN_H__
-#define PORTABLE_ENDIAN_H__
+    #define PORTABLE_ENDIAN_H__
 
-#if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && !defined(__WINDOWS__)
+    #if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && !defined(__WINDOWS__)
 
-#	define __WINDOWS__
+        #define __WINDOWS__
+        #include <winsock2.h>
 
-#endif
+    #elif defined(__linux__) || defined(__CYGWIN__)
 
-#if defined(__linux__) || defined(__CYGWIN__)
+        #include <arpa/inet.h>
+        #include <endian.h>
 
-#       include <arpa/inet.h>
-#	include <endian.h>
-#	define ntohll(x)  be64toh(x)
-#	define htonll(x)  htobe64(x)
+        #undef ntohll
+        #undef htonll
 
-#elif defined(__APPLE__)
+        #define ntohll(x)  be64toh(x)
+        #define htonll(x)  htobe64(x)
 
-#       include <arpa/inet.h>
-#	include <libkern/OSByteOrder.h>
+    #elif defined(__APPLE__)
 
-#	define ntohll(x)  OSSwapBigToHostInt64(x)
-#	define htonll(x)  OSSwapHostToBigInt64(x)
+        #include <arpa/inet.h>
+        #include <libkern/OSByteOrder.h>
 
-#elif defined(__OpenBSD__)
+        #undef ntohll
+        #undef htonll
 
-#	include <sys/endian.h>
-#       include <arpa/inet.h>
-#	define ntohll(x)  be64toh(x)
-#	define htonll(x)  htobe64(x)
+        #define ntohll(x)  OSSwapBigToHostInt64(x)
+        #define htonll(x)  OSSwapHostToBigInt64(x)
 
-#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+    #elif defined(__OpenBSD__)
 
-#	include <sys/endian.h>
-#       include <arpa/inet.h>
+        #include <sys/endian.h>
+        #include <arpa/inet.h>
 
-#	define be64toh(x) betoh64(x)
+        #undef ntohll
+        #undef htonll
 
-#	define ntohll(x)  be64toh(x)
-#	define htonll(x)  htobe64(x)
+        #define ntohll(x)  be64toh(x)
+        #define htonll(x)  htobe64(x)
 
-#elif defined(__WINDOWS__)
+    #elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
 
-#	include <winsock2.h>
-#else
+        #include <sys/endian.h>
+        #include <arpa/inet.h>
 
-#	error platform not supported
+        #undef ntohll
+        #undef htonll
+        #undef be64toh
 
-#endif
+        #define be64toh(x) betoh64(x)
+        #define ntohll(x)  be64toh(x)
+        #define htonll(x)  htobe64(x)
+
+    #else
+
+        #error platform not supported
+
+    #endif
 
 #endif

--- a/pyorient_native/version_compare.h
+++ b/pyorient_native/version_compare.h
@@ -1,0 +1,71 @@
+/* Sam Caldwell <mail@samcaldwell.net> (released public domain to the project where this code resides).
+ * Version Comparison Class.
+ *
+ * Given a version string in the form xxx.yyy.zzz.aaa, this class will parse the string
+ * and allow version comparison operators to test equivalence, etc. Expected behavior is
+ * defined in test_version_compare.cpp (in tests/ directory).
+ *
+ */
+#ifndef VERSION_COMPARE_H
+#define VERSION_COMPARE_H
+#endif
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+class Version {
+public:
+	Version(const char *c){
+		string version(c);
+		this->major = 0;
+		this->minor = 0;
+		this->revision = 0;
+		this->build = 0;
+		std::sscanf(version.c_str(), "%d.%d.%d.%d", &this->major, &this->minor, &this->revision, &this->build);
+	}
+
+	bool operator<(const Version rhs){
+		if (this->major < rhs.major)
+			return true;
+		if (this->minor < rhs.minor)
+			return true;
+		if (this->revision < rhs.revision)
+			return true;
+		if (this->build < rhs.build)
+			return true;
+		return false;
+	}
+
+	bool operator>(const Version rhs){
+		if (this->major > rhs.major)
+			return true;
+		if (this->minor > rhs.minor)
+			return true;
+		if (this->revision > rhs.revision)
+			return true;
+		if (this->build > rhs.build)
+			return true;
+		return false;
+	}
+
+	bool operator==(const Version rhs){
+		return this->major == rhs.major
+			   && this->minor == rhs.minor
+			   && this->revision == rhs.revision
+			   && this->build == rhs.build;
+	}
+
+	bool operator!=(const Version rhs){
+		return this->major != rhs.major
+			   && this->minor != rhs.minor
+			   && this->revision != rhs.revision
+			   && this->build != rhs.build;
+	}
+
+public:
+	int major = 0;
+	int minor = 0;
+	int revision = 0;
+	int build = 0;
+};

--- a/pyorient_native/version_compare.h
+++ b/pyorient_native/version_compare.h
@@ -64,8 +64,8 @@ public:
 	}
 
 public:
-	int major = 0;
-	int minor = 0;
-	int revision = 0;
-	int build = 0;
+	int major;
+	int minor;
+	int revision;
+	int build;
 };

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[aliases]
+test=pytest
+
+[tool:pytest]
+addopts = --verbose --exitfirst

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,12 @@
+from os.path import join, dirname, abspath
 from setuptools import find_packages, setup, Extension
+
+
+def read_file(file_name):
+    here = abspath(dirname(__file__))
+    with open(join(here, file_name), encoding='utf-8') as f:
+        return f.read()
+
 
 h_files = [
     "pyorient_native/orientc_reader.h",
@@ -26,11 +34,12 @@ pyorient_native = Extension(
     language="c++",
     libraries=["stdc++"]
 )
+
 setup(
     name="pyorient_native",
     version="1.2.4",
     description="OrientDB Binary Serialization package for python",
-    long_description=open('README.md').read(),
+    long_description=read_file('README.md'),
     author="Nikul Ukani",
     author_email="nhu2001@columbia.edu",
     classifiers=[
@@ -52,9 +61,7 @@ setup(
     ),
     extras_require={
         'test': [
-            'coverage',
             'pytest',
-            'pytest-cov',
             'pytest-cython'
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ pyorient_native = Extension(
 )
 setup(
     name="pyorient_native",
-    version="1.2.3",
+    version="1.2.4",
     description="OrientDB Binary Serialization package for python",
     author="Nikul Ukani",
     author_email="nhu2001@columbia.edu",
@@ -49,6 +49,14 @@ setup(
             'tests'
         ]
     ),
+    extras_require={
+        'test': [
+            'coverage',
+            'pytest',
+            'pytest-cov',
+            'pytest-cython'
+        ],
+    },
     url="https://github.com/nikulukani/pyorient_native",
     download_url="https://github.com/nikulukani/pyorient_native/"
                  "archive/1.2.3.tar.gz"

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,9 @@ setup(
             'pytest-cython'
         ],
     },
+    setup_requires=["pytest-runner"],
+    tests_require=["pytest"],
+    zip_safe=False,
     url="https://github.com/nikulukani/pyorient_native",
     download_url="https://github.com/nikulukani/pyorient_native/"
                  "archive/1.2.3.tar.gz"

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     name="pyorient_native",
     version="1.2.4",
     description="OrientDB Binary Serialization package for python",
+    long_description=open('README.md').read(),
     author="Nikul Ukani",
     author_email="nhu2001@columbia.edu",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,23 @@ setup(
     description="OrientDB Binary Serialization package for python",
     author="Nikul Ukani",
     author_email="nhu2001@columbia.edu",
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Libraries',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: C++'
+    ],
     ext_modules=[pyorient_native],
-    packages=find_packages(),
+    packages=find_packages(
+        exclude=[
+            'build',
+            'docs',
+            'tests'
+        ]
+    ),
     url="https://github.com/nikulukani/pyorient_native",
     download_url="https://github.com/nikulukani/pyorient_native/"
                  "archive/1.2.3.tar.gz"

--- a/tests/test_pyorient_native_load.py
+++ b/tests/test_pyorient_native_load.py
@@ -1,0 +1,17 @@
+"""
+    This file contains a test to load pyorient_native
+    created by Sam Caldwell <mail@samcaldwell.net>
+"""
+import unittest
+
+
+class TestPyorientNativeLoad(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_module_load(self):
+        try:
+            import pyorient_native
+            assert True
+        except Exception as e:
+            assert False, "failed to load pyorient_native,  {}".format(e)

--- a/tests/test_version_compare.cpp
+++ b/tests/test_version_compare.cpp
@@ -1,0 +1,110 @@
+/* Sam Caldwell <mail@samcaldwell.net> (released public domain to the project where this code resides).
+ * This file contains the tests for the version_compare.h source file.
+ */
+#include "../pyorient_native/version_compare.h"
+#include <assert.h>
+#include <iostream>
+
+/*void show_values(Version v1, Version v2){
+	cout << "show_values():\n";
+	cout << "\tv1: " << v1.major << "." << v1.minor << "." << v1.revision << "." << v1.build << "\n";
+	cout << "\tv2: " << v2.major << "." << v2.minor << "." << v2.revision << "." << v2.build << "\n";
+	cout << "\t---\n";
+}*/
+
+bool test_equivalence_operator_happy(){
+	cout << "test: test_equivalence_operator_happy() starting\n";
+	const char *version_string = "1.0.0";
+
+	Version v1(version_string);
+	Version v2(version_string);
+
+	return (v1 == v2);
+}
+
+bool test_equivalence_operator_sad(){
+	cout << "test: test_equivalence_operator_sad(): starting\n";
+	const char *version_string1 = "1.0.0";
+	const char *version_string2 = "2.0.0";
+
+	Version v1(version_string1);
+	Version v2(version_string2);
+
+	return !(v1 == v2);
+}
+
+bool test_less_than_operator_happy(){
+	cout << "test: test_less_than_operator_happy(): starting\n";
+	const char *version_string1 = "1.0.0";
+	const char *version_string2 = "1.0.1";
+
+	Version v1(version_string1);
+	Version v2(version_string2);
+
+	return (v1 < v2);
+}
+
+bool test_less_than_operator_sad_if_equal(){
+	cout << "test: test_less_than_operator_sad_if_equal(): starting\n";
+	const char *version_string1 = "1.0.0";
+	const char *version_string2 = "1.0.0";
+
+	Version v1(version_string1);
+	Version v2(version_string2);
+
+	return !(v1 < v2);
+}
+
+bool test_less_than_operator_sad_if_greater(){
+	cout << "test: test_less_than_operator_sad_if_greater(): starting\n";
+	const char *version_string1 = "2.0.0";
+	const char *version_string2 = "1.0.0";
+
+	Version v1(version_string1);
+	Version v2(version_string2);
+
+	return !(v1 < v2);
+}
+
+bool test_inequal_operator_happy(){
+	cout << "test: test_less_than_operator_sad_if_greater(): starting\n";
+	const char *version_string1 = "2.0.0";
+	const char *version_string2 = "1.0.0";
+
+	Version v1(version_string1);
+	Version v2(version_string2);
+
+	return (v1 != v2);
+}
+
+bool test_inequal_operator_sad(){
+	cout << "test: test_less_than_operator_sad_if_greater(): starting\n";
+	const char *version_string1 = "1.0.0";
+	const char *version_string2 = "1.0.0";
+
+	Version v1(version_string1);
+	Version v2(version_string2);
+
+	return !(v1 != v2);
+}
+
+bool test_casted_comparison_happy(){
+	cout << "test: test_casted_comparison_happy(): starting\n";
+	return (Version)("1.0") == (Version)("1.0");
+}
+bool test_casted_comparison_sad(){
+	cout << "test: test_casted_comparison_sad(): starting\n";
+	return (Version)("1.0") == (Version)("1.0");
+}
+
+int main(){
+	cout << "\n\nStarting tests.\n";
+
+	assert (test_equivalence_operator_happy());
+	assert (test_equivalence_operator_sad());
+	assert (test_less_than_operator_happy());
+	assert (test_less_than_operator_sad_if_equal());
+	assert (test_less_than_operator_sad_if_greater());
+	assert (test_casted_comparison_happy());
+	assert (test_casted_comparison_sad());
+}

--- a/tests/test_version_compare.py
+++ b/tests/test_version_compare.py
@@ -1,0 +1,34 @@
+"""
+    1. Compile test_version_compare.cpp
+    2. Execute the version test.
+    3. If exit_code == 0, success
+    4. else fail.
+"""
+import unittest
+import subprocess
+from os.path import join, dirname, exists
+
+
+class TestVersionCompare(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_version_compare_compile(self):
+        file = join(dirname(__file__), "bin", "test_version.bin")
+        src = join(dirname(__file__), "test_version_compare.cpp")
+        assert exists(src), "missing source file"
+        cmd = ["g++", "-o", file, src]
+        print("processing {}".format(cmd))
+        assert subprocess.run(cmd).returncode == 0, "Compile command failed."
+        assert exists(file), "missing target file"
+
+    def test_version_compare_execute(self):
+        file = join(dirname(__file__), "bin", "test_version.bin")
+        src = join(dirname(__file__), "test_version_compare.cpp")
+        assert exists(src), "missing source file"
+        cmd = ["g++", "-o", file, src]
+        print("processing {}".format(cmd))
+        assert subprocess.run(cmd).returncode == 0, "Compile command failed."
+        assert exists(file), "missing target file"
+        cmd = [file]
+        assert subprocess.run(cmd).returncode == 0, "compile failed."

--- a/tests/test_version_compare.py
+++ b/tests/test_version_compare.py
@@ -1,8 +1,10 @@
 """
-    1. Compile test_version_compare.cpp
-    2. Execute the version test.
-    3. If exit_code == 0, success
-    4. else fail.
+    This file contains a test for the version compare class
+    created by Sam Caldwell <mail@samcaldwell.net>
+
+    This will compile a c++ test program using the version compare class
+    and run that binary test.  It should be cross platform as it is a simple
+    string operation.
 """
 import unittest
 import subprocess


### PR DESCRIPTION
Fix various errors:
- MacOs compiler warnings (due to macro redefinition).
- linter fixes
- update gitignore
- implement pytest automation via setup.py